### PR TITLE
OGC: Make Fullscreen the Default

### DIFF
--- a/ball/main.c
+++ b/ball/main.c
@@ -17,6 +17,8 @@
 #include <SDL.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 #include "version.h"
 #include "glext.h"
@@ -544,7 +546,7 @@ int main(int argc, char *argv[])
 
 #ifdef __WII__
     chdir("/apps/neverball");
-    setenv("SDL_WII_JOYSTICK_SIDEWAYS", "1", 1);
+    SDL_setenv("SDL_WII_JOYSTICK_SIDEWAYS", "1", 1);
 #endif
 
     if (!fs_init(argv[0]))

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -20,7 +20,7 @@ svn_version()
 
 git_version()
 {
-    if git_desc="$(git describe --dirty=+)"; then
+    if git_desc="$(git describe --tags --dirty=+)"; then
         echo "$git_desc" | sed -e 's/^neverball-//' -e 's/-g/-/g'
     fi
 }

--- a/share/config.c
+++ b/share/config.c
@@ -129,13 +129,13 @@ static struct
     const int   def;
     int         cur;
 } option_d[] = {
-    #ifdef __wii__
+    #ifdef __WII__
     { &CONFIG_FULLSCREEN,   "fullscreen",   1 },
     #else
     { &CONFIG_FULLSCREEN,   "fullscreen",   0 },
     #endif
     { &CONFIG_DISPLAY,      "display",      0 },
-    #ifdef __wii__
+    #ifdef __WII__
     { &CONFIG_WIDTH,        "width",        640 },
     { &CONFIG_HEIGHT,       "height",       480 },
     #else

--- a/share/config.c
+++ b/share/config.c
@@ -129,10 +129,19 @@ static struct
     const int   def;
     int         cur;
 } option_d[] = {
+    #ifdef __wii__
+    { &CONFIG_FULLSCREEN,   "fullscreen",   1 },
+    #else
     { &CONFIG_FULLSCREEN,   "fullscreen",   0 },
+    #endif
     { &CONFIG_DISPLAY,      "display",      0 },
+    #ifdef __wii__
+    { &CONFIG_WIDTH,        "width",        640 },
+    { &CONFIG_HEIGHT,       "height",       480 },
+    #else
     { &CONFIG_WIDTH,        "width",        800 },
     { &CONFIG_HEIGHT,       "height",       600 },
+    #endif
     { &CONFIG_STEREO,       "stereo",       0 },
     { &CONFIG_CAMERA,       "camera",       0 },
     { &CONFIG_TEXTURES,     "textures",     1 },

--- a/share/st_common.c
+++ b/share/st_common.c
@@ -478,6 +478,7 @@ struct mode
 };
 
 static const struct mode modes[] = {
+    #ifndef __WII__
     { 2560, 1440 },
     { 1920, 1200 },
     { 1920, 1080 },
@@ -491,6 +492,10 @@ static const struct mode modes[] = {
     { 1280, 720 },
     { 1024, 768 },
     { 800, 600 },
+    #endif
+    #ifdef __WII__
+    { 854, 480},
+    #endif
     { 640, 480 },
     { 480, 320 },
     { 320, 240 }


### PR DESCRIPTION
When testing aspect ratios I remebered to try neverball:
![imagem](https://github.com/user-attachments/assets/402648e6-f559-4a6f-b7bc-fda93b1d9aec)
It works but needs fullscreen on, so I enabled it and added it as a option
I also made it so the window is not created at 800x600 and commited changes I needed to be able to build this port

Also needed https://github.com/devkitPro/pacman-packages/pull/373 since jpeg turbo was trying to use Altivec and has no support for the Gekko/Broadway/Espresso paired single SIMD